### PR TITLE
makechrootpkg: keep {SRC,SRCPKG,PKG,LOG}DEST, MAKEFLAGS & PACKAGER values

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -341,7 +341,7 @@ main() {
 	[[ -n $makepkg_user && -z $(id -u "$makepkg_user") ]] && die 'Invalid makepkg user.'
 	makepkg_user=${makepkg_user:-${SUDO_USER:-$USER}}
 
-	check_root SOURCE_DATE_EPOCH,GNUPGHOME
+	check_root SOURCE_DATE_EPOCH,GNUPGHOME,SRCDEST,SRCPKGDEST,PKGDEST,LOGDEST,MAKEFLAGS,PACKAGER
 
 	# Canonicalize chrootdir, getting rid of trailing /
 	chrootdir=$(readlink -e "$passeddir")


### PR DESCRIPTION
If `makechrootpkg` is called as non-root, the {SRC,SRCPKG,PKG,LOG}DEST, MAKEFLAGS and PACKAGER environment variables are lost in the call to `check_root()`.

Add these to the passed keepenv list so that they are preserved instead.