### PR TITLE
makechrootpkg: fixing -U flag

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -410,7 +410,7 @@ main() {
 
 	download_sources "$copydir" "$makepkg_user"
 
-	prepare_chroot "$copydir" "$USER_HOME" "$keepbuilddir" "$run_namcap"
+	prepare_chroot "$copydir" "$USER_HOME" "$keepbuilddir" "$run_namcap" "$makepkg_user"
 
 	if arch-nspawn "$copydir" \
 		--bind="$PWD:/startdir" \

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -164,11 +164,12 @@ prepare_chroot() {
 	local USER_HOME=$2
 	local keepbuilddir=$3
 	local run_namcap=$4
+	local makepkg_user=$5
 
 	[[ $keepbuilddir = true ]] || rm -rf "$copydir/build"
 
 	local builduser_uid builduser_gid
-	builduser_uid="${SUDO_UID:-$UID}"
+	builduser_uid="$(id -u "$makepkg_user")"
 	builduser_gid="$(id -g "$builduser_uid")"
 	local install="install -o $builduser_uid -g $builduser_gid"
 	local x


### PR DESCRIPTION
calling `makechrootpkg` from root login (almost, twice `sudo -s`) resuls in error:
`==> ERROR: Running makepkg as root is not allowed ...`

`prepare_chroot()` guesses `builduser_uid` using `$SUDO_UID`/`$UID`, so -U flag isn't applied, line [171](https://github.com/archlinux/devtools/blob/321e998020cfdb337c1ebc1ac41f5e729b9e276c/makechrootpkg.in#L171)

if -U flag isn't set, it'll hold `$SUDO_USER`/`$USER`
replacing line 171 with `id -u makepgk_user` has the same result without -U and correct result with -U

BTW: makepkg_user already validated via call to `download_sources`, line [410](https://github.com/archlinux/devtools/blob/321e998020cfdb337c1ebc1ac41f5e729b9e276c/makechrootpkg.in#L410)
