### PR TITLE
offload-build: respect PKGDEST

### DIFF
--- a/offload-build
+++ b/offload-build
@@ -105,4 +105,4 @@ mapfile -t files < <(
             makepkg --packagelist
 ')
 
-(( ${#files[@]} )) && printf '%s\n' '' '-> copying files...' && scp "${files[@]/#/$server:}" .
+(( ${#files[@]} )) && printf '%s\n' '' '-> copying files...' && scp "${files[@]/#/$server:}" "${PKGDEST:-$PWD}"


### PR DESCRIPTION
makechrootpkg moves the build product to PKGDEST, or PWD if unset. Implement the same for offload-build.