### PR TITLE
makechrootpkg: run checkpkg automatically after build

### DIFF
--- a/archbuild.in
+++ b/archbuild.in
@@ -5,7 +5,7 @@ m4_include(lib/common.sh)
 m4_include(lib/archroot.sh)
 
 base_packages=(base-devel)
-makechrootpkg_args=(-c -n)
+makechrootpkg_args=(-c -n -C)
 
 cmd="${0##*/}"
 if [[ "${cmd%%-*}" == 'multilib' ]]; then

--- a/checkpkg.in
+++ b/checkpkg.in
@@ -22,6 +22,48 @@ elif [[ -r "$HOME/.makepkg.conf" ]]; then
 	source "$HOME/.makepkg.conf"
 fi
 
+usage() {
+    cat <<- _EOF_
+		Usage: ${BASH_SOURCE[0]##*/} [OPTIONS]
+
+		Searches for a locally built package corresponding to the PKGBUILD, and
+		downloads the last version of that package from the Pacman repositories.
+		It then compares the list of .so files provided by each version of the
+		package and outputs if there are soname differences for the new package.
+		A directory is also created using mktemp with files containing a file
+		list for both packages and a library list for both packages.
+
+		OPTIONS
+		    -r, --rmdir     Remove the temporary directory
+		    -h, --help      Show this help text
+_EOF_
+}
+
+RMDIR=0
+
+OPT_SHORT='rh'
+OPT_LONG=('rmdir' 'help')
+if ! parseopts "$OPT_SHORT" "${OPT_LONG[@]}" -- "$@"; then
+    exit 1
+fi
+set  -- "${OPTRET[@]}"
+
+while :; do
+    case $1 in
+        -r|--rmdir)
+            RMDIR=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift; break
+            ;;
+    esac
+    shift
+done
+
 if [[ ! -f PKGBUILD ]]; then
 	die 'This must be run in the directory of a built package.'
 fi
@@ -33,6 +75,7 @@ if [[ ${arch[0]} == 'any' ]]; then
 fi
 
 STARTDIR=$(pwd)
+(( RMDIR )) && trap 'rm -rf $TEMPDIR' EXIT INT TERM QUIT
 TEMPDIR=$(mktemp -d --tmpdir checkpkg-script.XXXX)
 
 for _pkgname in "${pkgname[@]}"; do
@@ -92,4 +135,4 @@ for _pkgname in "${pkgname[@]}"; do
 	fi
 done
 
-msg "Files saved to %s" "$TEMPDIR"
+(( RMDIR )) || msg "Files saved to %s" "$TEMPDIR"

--- a/checkpkg.in
+++ b/checkpkg.in
@@ -35,14 +35,16 @@ usage() {
 
 		OPTIONS
 		    -r, --rmdir     Remove the temporary directory
+		    -w, --warn      Print a warning in case of differences
 		    -h, --help      Show this help text
 _EOF_
 }
 
 RMDIR=0
+WARN=0
 
-OPT_SHORT='rh'
-OPT_LONG=('rmdir' 'help')
+OPT_SHORT='rwh'
+OPT_LONG=('rmdir' 'warn' 'help')
 if ! parseopts "$OPT_SHORT" "${OPT_LONG[@]}" -- "$@"; then
     exit 1
 fi
@@ -52,6 +54,9 @@ while :; do
     case $1 in
         -r|--rmdir)
             RMDIR=1
+            ;;
+        -w|--warn)
+            WARN=1
             ;;
         -h|--help)
             usage
@@ -128,7 +133,8 @@ for _pkgname in "${pkgname[@]}"; do
 	find-libprovides "$TEMPDIR/$oldpkg" 2>/dev/null | sort > "$TEMPDIR/libraries-$_pkgname-old"
 	find-libprovides "$pkgfile" 2>/dev/null | sort > "$TEMPDIR/libraries-$_pkgname"
 	if ! diff_output="$(sdiff -s "$TEMPDIR/libraries-$_pkgname-old" "$TEMPDIR/libraries-$_pkgname")"; then
-		msg "Sonames differ in $_pkgname!"
+		message="Sonames differ in $_pkgname!"
+		(( WARN )) && warning "$message" || msg "$message"
 		echo "$diff_output"
 	else
 		msg "No soname differences for %s." "$_pkgname"

--- a/doc/checkpkg.1.asciidoc
+++ b/doc/checkpkg.1.asciidoc
@@ -19,6 +19,16 @@ outputs if there are soname differences for the new package. A directory is
 also created using mktemp with files containing a file list for both packages
 and a library list for both packages.
 
+Options
+-------
+
+*-r, --rmdir*::
+	Remove the temporary directory created to contain the file and library list
+	of both packages.
+
+*-h, --help*::
+	Show a help text
+
 See Also
 --------
 

--- a/doc/checkpkg.1.asciidoc
+++ b/doc/checkpkg.1.asciidoc
@@ -26,6 +26,9 @@ Options
 	Remove the temporary directory created to contain the file and library list
 	of both packages.
 
+*-w, --warn*::
+	Print a warning instead of a regular message in case of soname differences.
+
 *-h, --help*::
 	Show a help text
 

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -28,6 +28,7 @@ keepbuilddir=0
 update_first=0
 clean_first=0
 run_namcap=0
+run_checkpkg=0
 temp_chroot=0
 
 bindmounts_ro=()
@@ -72,6 +73,7 @@ usage() {
 	echo '           Useful for maintaining multiple copies'
 	echo "           Default: $copy"
 	echo '-n         Run namcap on the package'
+	echo '-C         Run checkpkg on the package'
 	echo '-T         Build in a temporary directory'
 	echo '-U         Run makepkg as a specified user'
 	exit 1
@@ -289,7 +291,7 @@ move_products() {
 }
 # }}}
 
-while getopts 'hcur:I:l:nTD:d:U:' arg; do
+while getopts 'hcur:I:l:nCTD:d:U:' arg; do
 	case "$arg" in
 		c) clean_first=1 ;;
 		D) bindmounts_ro+=("--bind-ro=$OPTARG") ;;
@@ -299,6 +301,7 @@ while getopts 'hcur:I:l:nTD:d:U:' arg; do
 		I) install_pkgs+=("$OPTARG") ;;
 		l) copy="$OPTARG" ;;
 		n) run_namcap=1; makepkg_args+=(--install) ;;
+		C) run_checkpkg=1 ;;
 		T) temp_chroot=1; copy+="-$$" ;;
 		U) makepkg_user="$OPTARG" ;;
 		h|*) usage ;;
@@ -385,6 +388,11 @@ if arch-nspawn "$copydir" \
 	"${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
 	/chrootbuild "${makepkg_args[@]}"
 then
+	pkgnames=()
+	for pkgfile in "$copydir"/pkgdest/*; do
+		pkgfile=${pkgfile##*/};
+		pkgnames+=("${pkgfile%-*-*-*}");
+	done
 	move_products
 else
 	(( ret += 1 ))
@@ -399,5 +407,15 @@ if (( ret != 0 )); then
 		die "Build failed, check %s/build" "$copydir"
 	fi
 else
+	if (( run_checkpkg )); then
+		msg "Running checkpkg"
+		msg2 "Downloading current versions"
+		if pacman --noconfirm -Swdd --logfile /dev/null "${pkgnames[@]}"; then
+			msg2 "Checking packages"
+			sudo -u "$makepkg_user" checkpkg
+		else
+			warning "Skipped checkpkg due to missing packages"
+		fi
+	fi
 	true
 fi

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -412,7 +412,7 @@ else
 		msg2 "Downloading current versions"
 		if pacman --noconfirm -Swdd --logfile /dev/null "${pkgnames[@]}"; then
 			msg2 "Checking packages"
-			sudo -u "$makepkg_user" checkpkg --rmdir
+			sudo -u "$makepkg_user" checkpkg --rmdir --warn
 		else
 			warning "Skipped checkpkg due to missing packages"
 		fi

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -412,7 +412,7 @@ else
 		msg2 "Downloading current versions"
 		if pacman --noconfirm -Swdd --logfile /dev/null "${pkgnames[@]}"; then
 			msg2 "Checking packages"
-			sudo -u "$makepkg_user" checkpkg
+			sudo -u "$makepkg_user" checkpkg --rmdir
 		else
 			warning "Skipped checkpkg due to missing packages"
 		fi

--- a/zsh_completion.in
+++ b/zsh_completion.in
@@ -1,4 +1,4 @@
-#compdef archbuild archco arch-nspawn archrelease commitpkg finddeps makechrootpkg mkarchroot rebuildpkgs extrapkg=commitpkg corepkg=commitpkg testingpkg=commitpkg stagingpkg=commitpkg communitypkg=commitpkg community-testingpkg=commitpkg community-stagingpkg=commitpkg multilibpkg=commitpkg multilib-testingpkg=commitpkg extra-x86_64-build=archbuild testing-x86_64-build=archbuild staging-x86_64-build=archbuild multilib-build=archbuild multilib-testing-build=archbuild multilib-staging-build=archbuild kde-unstable-x86_64-build=archbuild gnome-unstable-x86_64-build=archbuild communityco=archco
+#compdef archbuild archco arch-nspawn archrelease commitpkg finddeps makechrootpkg mkarchroot rebuildpkgs extrapkg=commitpkg corepkg=commitpkg testingpkg=commitpkg stagingpkg=commitpkg communitypkg=commitpkg community-testingpkg=commitpkg community-stagingpkg=commitpkg multilibpkg=commitpkg multilib-testingpkg=commitpkg extra-x86_64-build=archbuild testing-x86_64-build=archbuild staging-x86_64-build=archbuild multilib-build=archbuild multilib-testing-build=archbuild multilib-staging-build=archbuild kde-unstable-x86_64-build=archbuild gnome-unstable-x86_64-build=archbuild communityco=archco checkpkg
 # License: Unspecified
 
 m4_include(lib/valid-tags.sh)
@@ -52,6 +52,11 @@ _mkarchroot_args=(
 _rebuildpkgs_args=(
 	'1:chroot_dir:_files -/'
 	'*:packages:_devtools_completions_all_packages'
+)
+
+_checkpkg_args=(
+	'(-r --rmdir)'{-r,--rmdir}'[Remove the temporary directory]'
+	'(-h --help)'{-h,--help}'[Display usage]'
 )
 
 _devtools_completions_all_packages() {

--- a/zsh_completion.in
+++ b/zsh_completion.in
@@ -56,6 +56,7 @@ _rebuildpkgs_args=(
 
 _checkpkg_args=(
 	'(-r --rmdir)'{-r,--rmdir}'[Remove the temporary directory]'
+	'(-w --warn)'{-w,--warn}'[Print a warning in case of differences]'
 	'(-h --help)'{-h,--help}'[Display usage]'
 )
 


### PR DESCRIPTION
Cache previous versions required for checkpkg via pacman to avoid
multiple downloads when running multiple times.

In case we can't download the packages, like while building out of repo
packages, print a warning instead of running checkpkg