### PR TITLE
commitpkg: disallow if PKGBUILD hash mismatches package's enclosed hash

### DIFF
--- a/commitpkg.in
+++ b/commitpkg.in
@@ -91,7 +91,7 @@ for _arch in "${arch[@]}"; do
 	for _pkgname in "${pkgname[@]}"; do
 		fullver=$(get_full_version "$_pkgname")
 
-		if pkgfile=$(find_cached_package "$_pkgname" "$_arch" "$fullver"); then
+		if pkgfile=$(find_cached_package "$_pkgname" "$fullver" "$_arch"); then
 			if grep -q "packager = Unknown Packager" <(bsdtar -xOqf "$pkgfile" .PKGINFO); then
 				die "PACKAGER was not set when building package"
 			fi

--- a/commitpkg.in
+++ b/commitpkg.in
@@ -83,7 +83,7 @@ while getopts ':l:a:s:f' flag; do
 done
 shift $(( OPTIND - 1 ))
 
-# check packages have the packager field set
+# check packages for validity
 for _arch in "${arch[@]}"; do
 	if [[ -n $commit_arch && ${_arch} != "$commit_arch" ]]; then
 		continue
@@ -94,6 +94,11 @@ for _arch in "${arch[@]}"; do
 		if pkgfile=$(find_cached_package "$_pkgname" "$fullver" "$_arch"); then
 			if grep -q "packager = Unknown Packager" <(bsdtar -xOqf "$pkgfile" .PKGINFO); then
 				die "PACKAGER was not set when building package"
+			fi
+			hashsum=sha256sum
+			pkgbuild_hash=$(awk -v"hashsum=$hashsum" -F' = ' '$1 == "pkgbuild_"hashsum {print $2}' <(bsdtar -xOqf "$pkgfile" .BUILDINFO))
+			if [[ "$pkgbuild_hash" != "$($hashsum PKGBUILD|cut -d' ' -f1)" ]]; then
+				die "PKGBUILD $hashsum mismatch: expected $pkgbuild_hash"
 			fi
 		fi
 	done


### PR DESCRIPTION
Several cases showed that we release packages that were built with
different PKGBUILDs than the one commited to the source tree. This is
bad for obvious reasons plus sploils reproducible builds.

We, under no circumstances, want to allow using commitpkg to publish and
release a packages whose PKGBUILD doesn't match the one to be commited.