### PR TITLE
commitpkg: prefer explicit signature+data parameters for gpg --verify

### DIFF
--- a/commitpkg.in
+++ b/commitpkg.in
@@ -157,8 +157,8 @@ for _arch in "${arch[@]}"; do
 			fi
 			gpg --detach-sign --use-agent --no-armor "${SIGNWITHKEY[@]}" "${pkgfile}" || die
 		fi
-		if ! gpg --verify "$sigfile" >/dev/null 2>&1; then
-			die "Signature %s.sig is incorrect!" "$pkgfile"
+		if ! gpg --verify "$sigfile" "$pkgfile" >/dev/null 2>&1; then
+			die "Signature %s is incorrect!" "$sigfile"
 		fi
 		uploads+=("$sigfile")
 	done


### PR DESCRIPTION
Lets prefer the explicit variant of gpg --verify by providing both, the
signature and the data file as parameters.
For the unlikely case there is a matching signature file already present
that was created outside of the toolchain and has an embedded signature
with data, we at least could detect it early with this check.