### PR TITLE
commitpkg: Include commit msg arg in first line

### DIFF
--- a/commitpkg.in
+++ b/commitpkg.in
@@ -109,10 +109,10 @@ if [[ -z $server ]]; then
 fi
 
 if [[ -n $(svn status -q) ]]; then
-	msgtemplate="upgpkg: $pkgbase $(get_full_version)"$'\n\n'
+	msgtemplate="upgpkg: $pkgbase $(get_full_version)"
 	if [[ -n $1 ]]; then
 		stat_busy 'Committing changes to trunk'
-		svn commit -q -m "${msgtemplate}${1}" || die
+		svn commit -q -m "${msgtemplate} ${1}" || die
 		stat_done
 	else
 		msgfile="$(mktemp)"


### PR DESCRIPTION
Commit messages belong on the first line, with optional "explanatory
text" starting after a blank line:
https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Referencing commit ee970f0bde3c90a0dff909c366d4ab1a1bff9b9d

Signed-off-by: Daniel M. Capella <polyzen@archlinux.org>