### PR TITLE
sogrep: redirect to destination mirror

### DIFF
--- a/sogrep.in
+++ b/sogrep.in
@@ -41,7 +41,7 @@ recache() {
         for arch in "${arches[@]}"; do
             rm -rf "${SOCACHE_DIR}/${arch}/${repo}"
             mkdir -p "${SOCACHE_DIR}/${arch}/${repo}"
-            curl "$verbosity" "${SOLINKS_MIRROR}/${repo}/os/${arch}/${repo}.links.tar.gz" | bsdtar -xf - -C "${SOCACHE_DIR}/${arch}/${repo}"
+            curl -L "$verbosity" "${SOLINKS_MIRROR}/${repo}/os/${arch}/${repo}.links.tar.gz" | bsdtar -xf - -C "${SOCACHE_DIR}/${arch}/${repo}"
         done
     done
 }


### PR DESCRIPTION
Some mirrors redirect consumers to a near by mirror which isn't handled
by sogrep.