### PR TITLE
Rework the way mount args are built. This fixes #29 and probably #14.

### DIFF
--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -65,29 +65,20 @@ fi
 # shellcheck disable=2016
 host_mirrors=($($pacconf_cmd --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
 
-while read -r line; do
-	mapfile -t lines < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" \
-		--repo $line Server | sed -r 's#(.*/)[^/]+/os/.+#\1$repo/os/$arch#')
-	if [[ ${lines[0]} != ${host_mirrors[0]} ]]; then
-		for line in "${lines[@]}"; do
-			if [[ $line = file://* ]]; then
-				line=${line#file://}
-				in_array "$line" "${cache_dirs[@]}" || cache_dirs+=("$line")
-			fi
-		done
-	fi
-done < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" --repo-list)
-
 # {{{ functions
 build_mount_args() {
 	declare -g mount_args=()
 
-	for host_mirror in "${host_mirrors[@]}"; do
-		if [[ $host_mirror == *file://* ]]; then
-			host_mirror_path=$(echo "$host_mirror" | sed -r 's#file://(/.*)/\$repo/os/\$arch#\1#g')
-			mount_args+=("--bind-ro=${host_mirror_path//:/\\:}")
-		fi
-	done
+	while read -r repo; do
+		mapfile -t servers < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" \
+			--repo $repo Server)
+		for server in "${servers[@]}"; do
+			if [[ $server = file://* ]]; then
+				cache_dir=${server#file://}
+				in_array "$cache_dir" "${cache_dirs[@]}" || cache_dirs+=("$cache_dir")
+			fi
+		done
+	done < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" --repo-list)
 
 	mount_args+=("--bind=${cache_dirs[0]//:/\\:}")
 


### PR DESCRIPTION
Move an improved version of the "while read -r ..." loop inside the
build_mount_args function and remove the first for loop in the function.

In the while loop, the repo name and architecture in a server url are
no longer replaced by sed with the $repo and $arch placeholder strings.
When a local repo url is added to the cache_dirs array and later, when
it is used to build --bind-ro args it represents a valid filesystem path.
systemd-nspwan won't throw a "Failed to stat [...]" error anymore.
An extra if was removed and more friendly variable named were used.

The first for loop was removed since the improved while loop now handles
all the cases.