### PR TITLE
offload-build: return failure if no package files were found

### DIFF
--- a/offload-build
+++ b/offload-build
@@ -115,5 +115,7 @@ mapfile -t files < <(
 if (( ${#files[@]} )); then
     printf '%s\n' '' '-> copying files...'
     load_makepkg_config
-    scp "${files[@]/#/$server:}" "${PKGDEST:-${PWD}}/"
+    scp "${files[@]/#/$server:}" "${PKGDEST:-${PWD}}/" && exit 0
 fi
+
+exit 1


### PR DESCRIPTION
This will make integration of offload-build into other tools easier as it behaves closer to the actual build command.