### PR TITLE
makerepropkg: prioritize downloading .zst packages over legacy format

### DIFF
--- a/makerepropkg.in
+++ b/makerepropkg.in
@@ -60,7 +60,7 @@ get_pkgfile() {
     local pkgname=${pkgfilebase%-*-*-*}
     local pkgfile ext
 
-    for ext in .xz .zst ''; do
+    for ext in .zst .xz ''; do
         pkgfile=${pkgfilebase}.pkg.tar${ext}
 
         for c in "${cache_dirs[@]}"; do


### PR DESCRIPTION
First try a .zst location before falling back to legacy variants. This
should slightly speed up downloading of dependencies, especially over
time as .zst packages are or will be the dominant format.

Signed-off-by: Levente Polyak <anthraxx@archlinux.org>