### PR TITLE
offload-build: retrieve the PKGBUILD in case makepkg changes it via pkgver

### DIFF
--- a/offload-build.in
+++ b/offload-build.in
@@ -81,12 +81,13 @@ fi
 
 archbuild_cmd=("${repo}${archbuild_arch:+-$archbuild_arch}-build" "$@")
 
-trap 'rm -rf $SRCPKGDEST' EXIT INT TERM QUIT
+trap 'rm -rf $TEMPDIR' EXIT INT TERM QUIT
 
 # Use a source-only tarball as an intermediate to transfer files. This
 # guarantees the checksums are okay, and guarantees that all needed files are
 # transferred, including local sources, install scripts, and changelogs.
-export SRCPKGDEST=$(mktemp -d)
+export TEMPDIR=$(mktemp -d --tmpdir offload-build.XXXXXXXXXX)
+export SRCPKGDEST=${TEMPDIR}
 makepkg --source || die "unable to make source package"
 
 # Temporary cosmetic workaround makepkg if SRCDEST is set somewhere else
@@ -114,14 +115,17 @@ mapfile -t files < <(
             if [[ -f /usr/share/devtools/makepkg-'"${repo}"'-'"${arch}"'.conf ]]; then
                 makepkg_config="/usr/share/devtools/makepkg-'"${repo}"'-'"${arch}"'.conf"
             fi &&
-            makepkg --config <(cat "${makepkg_user_config}" "${makepkg_config}" 2>/dev/null) --packagelist
+            makepkg --config <(cat "${makepkg_user_config}" "${makepkg_config}" 2>/dev/null) --packagelist &&
+            printf "%s\n" "${temp}/PKGBUILD"
 ')
 
 
 if (( ${#files[@]} )); then
     printf '%s\n' '' '-> copying files...'
     load_makepkg_config
-    scp "${files[@]/#/$server:}" "${PKGDEST:-${PWD}}/"
+    scp "${files[@]/#/$server:}" "${TEMPDIR}/"
+    mv "${TEMPDIR}"/*.pkg.tar* "${PKGDEST:-${PWD}}/"
+    mv "${TEMPDIR}/PKGBUILD" "${PWD}/"
 else
     exit 1
 fi


### PR DESCRIPTION
Building a package may change the PKGBUILD during update_pkgver. Let's
retrieve the PKGBUILD after building to ensure we have the very same
file as the one we used to build the package. Otherwise this may lead to
the inability to distribute the package during commitpkg in case the
expected and the actual hashsum mismatch.