### PR TITLE
Expose failed build artifacts.

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -367,10 +367,10 @@ if arch-nspawn "$copydir" \
 	/chrootbuild "${makepkg_args[@]}"
 then
 	mapfile -t pkgnames < <(sudo -u "$makepkg_user" bash -c 'source PKGBUILD; printf "%s\n" "${pkgname[@]}"')
-	move_products
 else
 	(( ret += 1 ))
 fi
+move_products
 
 (( temp_chroot )) && delete_chroot "$copydir" "$copy"
 


### PR DESCRIPTION
Since move_products() function is fairly robust
we can make it run for failed build also to expose
logs for packages that fails in build(), prepare()
or package(). It also exposes partially packaged
split packages if they fail in latter package_xxx().