### PR TITLE
honor nosetarch all the way

### DIFF
--- a/archbuild.in
+++ b/archbuild.in
@@ -34,16 +34,18 @@ usage() {
 	echo '    -h         This help'
 	echo '    -c         Recreate the chroot before building'
 	echo '    -r <dir>   Create chroots in this directory'
+	echo '    -s         Do not run setarch'
 	echo ''
 	echo "Default makechrootpkg args: ${makechrootpkg_args[*]}"
 	echo ''
 	exit 1
 }
 
-while getopts 'hcr:' arg; do
+while getopts 'hcr:s' arg; do
 	case "${arg}" in
 		c) clean_first=true ;;
 		r) chroots="$OPTARG" ;;
+		s) nosetarch_opt="-s" ;;
 		*) usage ;;
 	esac
 done
@@ -51,7 +53,7 @@ done
 check_root SOURCE_DATE_EPOCH,SRCDEST,SRCPKGDEST,PKGDEST,LOGDEST,MAKEFLAGS,PACKAGER,GNUPGHOME
 
 # Pass all arguments after -- right to makepkg
-makechrootpkg_args+=("${@:$OPTIND}")
+makechrootpkg_args+=("${nosetarch_opt}" "${@:$OPTIND}")
 
 if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 	msg "Creating chroot for [%s] (%s)..." "${repo}" "${arch}"
@@ -69,14 +71,14 @@ if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 
 	rm -rf --one-file-system "${chroots}/${repo}-${arch}"
 	(umask 0022; mkdir -p "${chroots}/${repo}-${arch}")
-	setarch "${arch}" mkarchroot \
+	mkarchroot ${nosetarch_opt} \
 		-C "${pacman_config}" \
 		-M "${makepkg_config}" \
 		"${chroots}/${repo}-${arch}/root" \
 		"${base_packages[@]}" || abort
 else
 	lock 9 "${chroots}/${repo}-${arch}/root.lock" "Locking clean chroot"
-	arch-nspawn \
+	arch-nspawn ${nosetarch_opt} \
 		-C "${pacman_config}" \
 		-M "${makepkg_config}" \
 		"${chroots}/${repo}-${arch}/root" \

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -145,7 +145,7 @@ install_packages() {
 	pkgnames=("${install_pkgs[@]##*/}")
 
 	cp -- "${install_pkgs[@]}" "$copydir/root/"
-	arch-nspawn "$copydir" "${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
+	arch-nspawn ${nosetarch_opt} "$copydir" "${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
 		bash -c 'yes y | pacman -U -- "$@"' -bash "${pkgnames[@]/#//root/}"
 	ret=$?
 	rm -- "${pkgnames[@]/#/$copydir/root/}"
@@ -342,7 +342,7 @@ if [[ ! -d $copydir ]] || (( clean_first )); then
 	sync_chroot "$chrootdir" "$copydir" "$copy"
 fi
 
-(( update_first )) && arch-nspawn "$copydir" \
+(( update_first )) && arch-nspawn ${nosetarch_opt} "$copydir" \
 		"${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
 		pacman -Syuu --noconfirm
 
@@ -399,7 +399,7 @@ else
 		for remotepkg in "${remotepkgs[@]}"; do
 			if [[ $remotepkg != file://* ]]; then
 				msg2 "Downloading current versions"
-				arch-nspawn "$copydir" pacman --noconfirm -Swdd "${pkgnames[@]}"
+				arch-nspawn ${nosetarch_opt} "$copydir" pacman --noconfirm -Swdd "${pkgnames[@]}"
 				mapfile -t remotepkgs < <(pacman --config "$copydir"/etc/pacman.conf \
 					--dbpath "$copydir"/var/lib/pacman \
 					-Sddp "${pkgnames[@]}")

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -78,6 +78,7 @@ usage() {
 	echo '-C         Run checkpkg on the package'
 	echo '-T         Build in a temporary directory'
 	echo '-U         Run makepkg as a specified user'
+	echo '-s         Do not run setarch'
 	exit 1
 }
 
@@ -273,7 +274,7 @@ move_products() {
 }
 # }}}
 
-while getopts 'hcur:I:l:nCTD:d:U:' arg; do
+while getopts 'hcur:I:l:nCTD:d:U:s' arg; do
 	case "$arg" in
 		c) clean_first=1 ;;
 		D) bindmounts_ro+=("--bind-ro=$OPTARG") ;;
@@ -286,6 +287,7 @@ while getopts 'hcur:I:l:nCTD:d:U:' arg; do
 		C) run_checkpkg=1 ;;
 		T) temp_chroot=1; copy+="-$$" ;;
 		U) makepkg_user="$OPTARG" ;;
+		s) nosetarch_opt="-s" ;;
 		h|*) usage ;;
 	esac
 done
@@ -360,7 +362,7 @@ download_sources
 
 prepare_chroot
 
-if arch-nspawn "$copydir" \
+if arch-nspawn ${nosetarch_opt} "$copydir" \
 	--bind="${PWD//:/\\:}:/startdir" \
 	--bind="${SRCDEST//:/\\:}:/srcdest" \
 	"${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \


### PR DESCRIPTION
Fix `nosetarch` support which is honored by `arch-nspawn` and `mkarchroot` but not `archbuild` or `makechrootpkg`.