### PR TITLE
add option to install packages on recreating chroot

### DIFF
--- a/archbuild.in
+++ b/archbuild.in
@@ -34,16 +34,19 @@ usage() {
 	echo '    -h         This help'
 	echo '    -c         Recreate the chroot before building'
 	echo '    -r <dir>   Create chroots in this directory'
+	echo '    -I <pkgs>  Install extra packages on recreating chroot'
 	echo ''
 	echo "Default makechrootpkg args: ${makechrootpkg_args[*]}"
+	echo "Default packages: ${base_packages[*]}"
 	echo ''
 	exit 1
 }
 
-while getopts 'hcr:' arg; do
+while getopts 'hcr:I:' arg; do
 	case "${arg}" in
 		c) clean_first=true ;;
 		r) chroots="$OPTARG" ;;
+		I) base_packages+=($OPTARG) ;;
 		*) usage ;;
 	esac
 done

--- a/zsh_completion.in
+++ b/zsh_completion.in
@@ -9,6 +9,7 @@ _binary_arch=${_arch[*]:0:-1}
 _archbuild_args=(
 	'-c[Recreate the chroot before building]'
 	'-r[Create chroots in this directory]:base_dir:_files -/'
+	'-I[Install extra packages on recreating chroot]:packages:_devtools_completions_all_packages'
 	'-h[Display usage]'
 )
 


### PR DESCRIPTION
For official repo, `base-devel` is an implicit `makedepends`. Howerver, when building other packages, i.e. `pkgname-git`, it needs `git` or `svn`. Or we may want `distcc` ahead for cross compilation. 

Add an option to install packages on recreating chroot.