### PR TITLE
Obsolete nosetarch option

### DIFF
--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -31,7 +31,6 @@ usage() {
 	echo '    -M <file>     Location of a makepkg config file'
 	echo '    -c <dir>      Set pacman cache'
 	echo '    -f <file>     Copy file from the host to the chroot'
-	echo '    -s            Do not run setarch'
 	echo '    -h            This message'
 	exit 1
 }
@@ -42,7 +41,6 @@ while getopts 'hC:M:c:f:s' arg; do
 		M) makepkg_conf="$OPTARG" ;;
 		c) cache_dirs+=("$OPTARG") ;;
 		f) files+=("$OPTARG") ;;
-		s) nosetarch=1 ;;
 		h|?) usage ;;
 		*) error "invalid argument '%s'" "$arg"; usage ;;
 	esac
@@ -124,8 +122,7 @@ fi
 copy_hostconf
 
 eval "$(grep -a '^CARCH=' "$working_dir/etc/makepkg.conf")"
-
-[[ -z $nosetarch ]] || unset CARCH
+setarch --list | grep -qx "$CARCH" || unset CARCH
 
 exec ${CARCH:+setarch "$CARCH"} systemd-nspawn -q \
 	-D "$working_dir" \

--- a/archbuild.in
+++ b/archbuild.in
@@ -69,7 +69,10 @@ if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 
 	rm -rf --one-file-system "${chroots}/${repo}-${arch}"
 	(umask 0022; mkdir -p "${chroots}/${repo}-${arch}")
-	setarch "${arch}" mkarchroot \
+
+	setarch --list | grep -qx "$arch" && setarch_cmd="setarch $arch"
+
+	${setarch_cmd} mkarchroot \
 		-C "${pacman_config}" \
 		-M "${makepkg_config}" \
 		"${chroots}/${repo}-${arch}/root" \

--- a/doc/mkarchroot.1.asciidoc
+++ b/doc/mkarchroot.1.asciidoc
@@ -35,9 +35,6 @@ Options
 *-f* <file>::
 	Copy file from the host to the chroot.
 
-*-s*::
-	Do not run setarch.
-
 *-h*::
 	Output command line options.
 

--- a/mkarchroot.in
+++ b/mkarchroot.in
@@ -31,7 +31,6 @@ usage() {
 	echo '    -M <file>     Location of a makepkg config file'
 	echo '    -c <dir>      Set pacman cache'
 	echo '    -f <file>     Copy file from the host to the chroot'
-	echo '    -s            Do not run setarch'
 	echo '    -h            This message'
 	exit 1
 }
@@ -43,7 +42,6 @@ while getopts 'hUC:M:c:f:s' arg; do
 		M) makepkg_conf="$OPTARG" ;;
 		c) cache_dirs+=("$OPTARG") ;;
 		f) files+=("$OPTARG") ;;
-		s) nosetarch=1 ;;
 		h|?) usage ;;
 		*) error "invalid argument '%s'" "$arg"; usage ;;
 	esac

--- a/zsh_completion.in
+++ b/zsh_completion.in
@@ -21,7 +21,6 @@ _arch_nspawn_args=(
 	'-M[Location of a makepkg config file]:makepkg_config:_files -g "*.conf(.)"'
 	'-c[Set pacman cache]:pacman_cache:_files -/'
 	'-f[Copy file from the host to the chroot]:copy_file:_files'
-	'-s[Do not run setarch]'
 	'-h[Display usage]'
 	'1:chroot_dir:_files -/'
 )


### PR DESCRIPTION
setarch is mainly used for building i686 packages on x86_64, while it
disturbs building ARM packages on x86_64, so the nosetarch option (-s)
was introduced. But there is a better way that we could always precheck
the setarch support list, and do it only when available.

This could fix the partial implement of setarch refered on #41 .

Close #41 