### PR TITLE
allow to call setarch with a different value than $CARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ CONFIGFILES = \
 	pacman-kde-unstable.conf \
 	pacman-gnome-unstable.conf
 
+SETARCH_ALIASES = \
+
 COMMITPKG_LINKS = \
 	extrapkg \
 	testingpkg \
@@ -101,9 +103,10 @@ clean:
 
 install:
 	install -dm0755 $(DESTDIR)$(PREFIX)/bin
-	install -dm0755 $(DESTDIR)$(PREFIX)/share/devtools
+	install -dm0755 $(DESTDIR)$(PREFIX)/share/devtools/setarch-aliases.d
 	install -m0755 ${BINPROGS} $(DESTDIR)$(PREFIX)/bin
 	install -m0644 ${CONFIGFILES} $(DESTDIR)$(PREFIX)/share/devtools
+	for a in ${SETARCH_ALIASES}; do install -m0644 setarch-aliases.d/$$a $(DESTDIR)$(PREFIX)/share/devtools/setarch-aliases.d; done
 	for l in ${COMMITPKG_LINKS}; do ln -sf commitpkg $(DESTDIR)$(PREFIX)/bin/$$l; done
 	for l in ${ARCHBUILD_LINKS}; do ln -sf archbuild $(DESTDIR)$(PREFIX)/bin/$$l; done
 	for l in ${CROSSREPOMOVE_LINKS}; do ln -sf crossrepomove $(DESTDIR)$(PREFIX)/bin/$$l; done
@@ -119,6 +122,7 @@ install:
 uninstall:
 	for f in ${BINPROGS}; do rm -f $(DESTDIR)$(PREFIX)/bin/$$f; done
 	for f in ${CONFIGFILES}; do rm -f $(DESTDIR)$(PREFIX)/share/devtools/$$f; done
+	for f in ${SETARCH_ALIASES}; do rm -f $(DESTDIR)$(PREFIX)/share/devtools/setarch-aliases.d/$$f; done
 	for l in ${COMMITPKG_LINKS}; do rm -f $(DESTDIR)$(PREFIX)/bin/$$l; done
 	for l in ${ARCHBUILD_LINKS}; do rm -f $(DESTDIR)$(PREFIX)/bin/$$l; done
 	for l in ${CROSSREPOMOVE_LINKS}; do rm -f $(DESTDIR)$(PREFIX)/bin/$$l; done

--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -127,7 +127,7 @@ eval "$(grep -a '^CARCH=' "$working_dir/etc/makepkg.conf")"
 
 [[ -z $nosetarch ]] || unset CARCH
 if [[ -f "@pkgdatadir@/setarch-aliases.d/${CARCH}" ]]; then
-	set_arch=$(cat "@pkgdatadir@/setarch-aliases.d/${CARCH}")
+	read -r set_arch < "@pkgdatadir@/setarch-aliases.d/${CARCH}"
 else
 	set_arch="${CARCH}"
 fi

--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -126,8 +126,13 @@ copy_hostconf
 eval "$(grep -a '^CARCH=' "$working_dir/etc/makepkg.conf")"
 
 [[ -z $nosetarch ]] || unset CARCH
+if [[ -f "@pkgdatadir@/setarch-aliases.d/${CARCH}" ]]; then
+	set_arch=$(cat "@pkgdatadir@/setarch-aliases.d/${CARCH}")
+else
+	set_arch="${CARCH}"
+fi
 
-exec ${CARCH:+setarch "$CARCH"} systemd-nspawn -q \
+exec ${CARCH:+setarch "$set_arch"} systemd-nspawn -q \
 	-D "$working_dir" \
 	-E "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin" \
 	--register=no --keep-unit --as-pid2 \

--- a/archbuild.in
+++ b/archbuild.in
@@ -17,6 +17,11 @@ else
 	repo=${tag%-*}
 	arch=${tag##*-}
 fi
+if [[ -f "@pkgdatadir@/setarch-aliases.d/${arch}" ]]; then
+	set_arch=$(cat "@pkgdatadir@/setarch-aliases.d/${arch}")
+else
+	set_arch="${arch}"
+fi
 chroots='/var/lib/archbuild'
 clean_first=false
 
@@ -69,7 +74,7 @@ if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 
 	rm -rf --one-file-system "${chroots}/${repo}-${arch}"
 	(umask 0022; mkdir -p "${chroots}/${repo}-${arch}")
-	setarch "${arch}" mkarchroot \
+	setarch "${set_arch}" mkarchroot \
 		-C "${pacman_config}" \
 		-M "${makepkg_config}" \
 		"${chroots}/${repo}-${arch}/root" \

--- a/archbuild.in
+++ b/archbuild.in
@@ -18,7 +18,7 @@ else
 	arch=${tag##*-}
 fi
 if [[ -f "@pkgdatadir@/setarch-aliases.d/${arch}" ]]; then
-	set_arch=$(cat "@pkgdatadir@/setarch-aliases.d/${arch}")
+	read -r set_arch < "@pkgdatadir@/setarch-aliases.d/${arch}"
 else
 	set_arch="${arch}"
 fi


### PR DESCRIPTION
Introduce setarch-aliases.d/ which gets installed inside
/usr/share/devtools. This allows to assign aliases which map one CARCH
to a different name which gets provided as argument for setarch. This is
necessary on archlinuxarm ("armv6h" -> "armv6l", "armv7h" -> "armv7l")
and allows for more fine-grained architectures (e.g. archlinux32 has
"i686" and "pentium4", which differ in the required cpu capabilities).

This would solve issue #44 
For a demonstration of how this can be used downstream, have a look at 82cf57ebcfe5469ef47c61dc4e91a9ddb77ab30f
7c9eb9269ee30b302d6cfc8005a33374cde53bb5
c8387401d80a48f8238f637f0cd1971bc63ef852