### PR TITLE
arch-nspawn should use the correct pacman config file

### DIFF
--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -64,7 +64,7 @@ if (( ${#cache_dirs[@]} == 0 )); then
 fi
 
 # shellcheck disable=2016
-host_mirrors=($($pacconf_cmd --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
+host_mirrors=($($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
 
 for host_mirror in "${host_mirrors[@]}"; do
 	if [[ $host_mirror == *file://* ]]; then


### PR DESCRIPTION
If arch-nspawn is called with -C, pacman inside the chroot will use
the provided configuration file. This should also be the case for
$pacconf_cmd and pacman outside the chroot.

If arch-nspawn is called without -C, pacman inside the chroot will
use $workdir/etc/pacman.conf -- again, $pacconf_cmd and pacman
outside the chroot should use that, too. So lets just set $pac_conf
in that case.

For example, Arch Linux 32 provides separate pacman configurations
inside /usr/share/devtools which use /etc/pacman.d/mirrorlist32 as
mirrorlist for their build commands (extra-i686-build, etc.). This
way, we can build i686 and x86_64 packages on the same x86_64 host
with very minimal changes to devtools.