### PR TITLE
archbuild: read CacheDir from corresponding pacman.conf when mkarchchroot

### DIFF
--- a/archbuild.in
+++ b/archbuild.in
@@ -52,6 +52,7 @@ check_root SOURCE_DATE_EPOCH,SRCDEST,SRCPKGDEST,PKGDEST,LOGDEST,MAKEFLAGS,PACKAG
 
 # Pass all arguments after -- right to makepkg
 makechrootpkg_args+=("${@:$OPTIND}")
+cachedir=$(pacman-conf -c "${pacman_config}" CacheDir)
 
 if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 	msg "Creating chroot for [%s] (%s)..." "${repo}" "${arch}"
@@ -72,6 +73,7 @@ if ${clean_first} || [[ ! -d "${chroots}/${repo}-${arch}" ]]; then
 	setarch "${arch}" mkarchroot \
 		-C "${pacman_config}" \
 		-M "${makepkg_config}" \
+		-c "${cachedir}" \
 		"${chroots}/${repo}-${arch}/root" \
 		"${base_packages[@]}" || abort
 else


### PR DESCRIPTION
Useful when the architectures of the host machine and the target chroot are different.
eg. x86_64 host creating an i686 chroot, or aarch64 host creating an armv7h chroot