### PR TITLE
makechrootpkg: fix an infinite loop when installing package with -I

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -145,7 +145,7 @@ install_packages() {
 
 	cp -- "${install_pkgs[@]}" "$copydir/root/"
 	arch-nspawn "$copydir" "${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
-		bash -c 'yes y | pacman -U -- "$@"' -bash "${pkgnames[@]/#//root/}"
+		bash -c 'pacman -U --noconfirm -- "$@"' -bash "${pkgnames[@]/#//root/}"
 	ret=$?
 	rm -- "${pkgnames[@]/#/$copydir/root/}"
 


### PR DESCRIPTION
When installing with the `-I` option a package which in turn has a dependency with multiple providers, makechrootpkg enters in an infinite loop. This happens because we are using the `pacman -U` command piped with `yes y`. The `yes y` command outputs only `y` lines, but when installing a dependency package with multiple providers pacman expects a number as the input. Being such, makechrootpkg outputs this endlessly:

```
Enter a number (default=1): error: invalid number: y
```

Using the pacman `--noconfirm` option without piping `yes y` fixes the issue.

There are other ways to fix it, like piping `while :; do printf "y\n1\n"; done` instead of `yes y`, but simply using `--noconfirm` looks simpler and better.

Example package to reproduce: [flutter](https://aur.archlinux.org/packages/flutter/)<sup>AUR</sup> (depends on [android-sdk](https://aur.archlinux.org/packages/android-sdk/)<sup>AUR</sup>). When executing `extra-x86_64-build -- -I /path/to/android-sdk-26.1.1-1-x86_64.pkg.tar.zst`, it will enter in an infinite loop because `java-environment` (dependency of [android-sdk](https://aur.archlinux.org/packages/android-sdk/)<sup>AUR</sup> that is being installed with `-I`) has multiple providers.