### PR TITLE
makechrootpkg: Only expose failed build logs instead of products

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -242,6 +242,15 @@ download_sources() {
 		die "Could not download sources."
 }
 
+move_logfiles() {
+	local l
+	for l in "$copydir"/logdest/*; do
+		[[ $l == */logpipe.* ]] && continue
+		chown "$src_owner" "$l"
+		mv "$l" "$LOGDEST"
+	done
+}
+
 move_products() {
 	local pkgfile
 	for pkgfile in "$copydir"/pkgdest/*; do
@@ -254,12 +263,7 @@ move_products() {
 		fi
 	done
 
-	local l
-	for l in "$copydir"/logdest/*; do
-		[[ $l == */logpipe.* ]] && continue
-		chown "$src_owner" "$l"
-		mv "$l" "$LOGDEST"
-	done
+	move_logfiles
 
 	for s in "$copydir"/srcpkgdest/*; do
 		chown "$src_owner" "$s"
@@ -367,10 +371,11 @@ if arch-nspawn "$copydir" \
 	/chrootbuild "${makepkg_args[@]}"
 then
 	mapfile -t pkgnames < <(sudo -u "$makepkg_user" bash -c 'source PKGBUILD; printf "%s\n" "${pkgname[@]}"')
+	move_products
 else
 	(( ret += 1 ))
+	move_logfiles
 fi
-move_products
 
 (( temp_chroot )) && delete_chroot "$copydir" "$copy"
 


### PR DESCRIPTION
After further followups always moving all products isn't actually
desired as they can theoretically be broken in various ways if
arch-nspawn exists non successful.

However, as we would like to always preserve the produced log files we
instead split out the logfiles into an own function and call that for
unsuccessful buils.

Fixes 4f305aa3