### PR TITLE
zsh-completion: complete makechrootpkg arguments after `*-build --`

### DIFF
--- a/zsh_completion.in
+++ b/zsh_completion.in
@@ -10,6 +10,7 @@ _archbuild_args=(
 	'-c[Recreate the chroot before building]'
 	'-r[Create chroots in this directory]:base_dir:_files -/'
 	'-h[Display usage]'
+	'--[Introduce makechrootpkg options]:*::makechrootpkg options:=  _dispatch makechrootpkg makechrootpkg'
 )
 
 _archco_args=(


### PR DESCRIPTION
I'm motivated to create this as I often type `extra-x86_64-build -- -I xxx.pkg.tar.zst`, and unable to completing the package filename is annoying.

Note that I'm far from a talented zsh programmar. This patch works for me and I didn't see other issues for some time, but there might be hidden bugs.

Demonstration:
```
$ extra-x86_64-build -- -
-D  -- Bind directory into build chroot as read-only
-I  -- Install a package into the working copy
-T  -- Build in a temporary directory
-U  -- Run makepkg as a specified user
-c  -- Clean the chroot before building
-d  -- Bind directory into build chroot as read-write
-h  -- Display usage
-l  -- The directory to use as the working copy
-n  -- Run namcap on the package
-r  -- The chroot dir to use
-u  -- Update the working copy of the chroot before building
```