### PR TITLE
Drop pacutils:`pacconf` fallback

### DIFF
--- a/arch-nspawn.in
+++ b/arch-nspawn.in
@@ -57,14 +57,12 @@ shift 1
 
 [[ -z $working_dir ]] && die 'Please specify a working directory.'
 
-pacconf_cmd=$(command -v pacman-conf || command -v pacconf)
-
 if (( ${#cache_dirs[@]} == 0 )); then
-	mapfile -t cache_dirs < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" CacheDir)
+	mapfile -t cache_dirs < <(pacman-conf --config "${pac_conf:-$working_dir/etc/pacman.conf}" CacheDir)
 fi
 
 # shellcheck disable=2016
-host_mirrors=($($pacconf_cmd --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
+host_mirrors=($(pacman-conf --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
 
 for host_mirror in "${host_mirrors[@]}"; do
 	if [[ $host_mirror == *file://* ]]; then
@@ -76,7 +74,7 @@ for host_mirror in "${host_mirrors[@]}"; do
 done
 
 while read -r line; do
-	mapfile -t lines < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" \
+	mapfile -t lines < <(pacman-conf --config "${pac_conf:-$working_dir/etc/pacman.conf}" \
 		--repo $line Server | sed -r 's#(.*/)[^/]+/os/.+#\1#')
 	for line in "${lines[@]}"; do
 		if [[ $line = file://* ]]; then
@@ -84,7 +82,7 @@ while read -r line; do
 			in_array "$line" "${cache_dirs[@]}" || cache_dirs+=("$line")
 		fi
 	done
-done < <($pacconf_cmd --config "${pac_conf:-$working_dir/etc/pacman.conf}" --repo-list)
+done < <(pacman-conf --config "${pac_conf:-$working_dir/etc/pacman.conf}" --repo-list)
 
 mount_args+=("--bind=${cache_dirs[0]//:/\\:}")
 

--- a/mkarchroot.in
+++ b/mkarchroot.in
@@ -63,10 +63,9 @@ shift 1
 
 [[ -z $working_dir ]] && die 'Please specify a working directory.'
 
-pacconf_cmd=$(command -v pacman-conf || command -v pacconf)
 
 if (( ${#cache_dirs[@]} == 0 )); then
-	mapfile -t cache_dirs < <($pacconf_cmd CacheDir)
+	mapfile -t cache_dirs < <(pacman-conf CacheDir)
 fi
 
 umask 0022


### PR DESCRIPTION
Fallback to `pacutils:pacconf` is no longer needed as of `pacman:5.2` .