### PR TITLE
feat: support exposing buildtool to aid reproducible builds configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ edit = sed -e "s|@pkgdatadir[@]|$(PREFIX)/share/devtools|g"
 %: %.in Makefile lib/common.sh
 	@echo "GEN $@"
 	@$(RM) "$@"
-	@{ echo -n 'm4_changequote([[[,]]])'; cat $@.in; } | m4 -P | $(edit) >$@
+	@{ echo -n 'm4_changequote([[[,]]])'; cat $@.in; } | m4 -P --define=m4_devtools_version=$V | $(edit) >$@
 	@chmod a-w "$@"
 	@chmod +x "$@"
 	@bash -O extglob -n "$@"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -14,6 +14,10 @@ $_INCLUDE_COMMON_SH
 # Avoid any encoding problems
 export LANG=C
 
+# Set buildtool properties
+export BUILDTOOL=devtools
+export BUILDTOOLVER=m4_devtools_version
+
 shopt -s extglob
 
 # check if messages are to be printed using color

--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -190,6 +190,8 @@ EOF
 		printf '#!/bin/bash\n'
 		declare -f _chrootbuild
 		declare -p SOURCE_DATE_EPOCH 2>/dev/null || true
+		declare -p BUILDTOOL 2>/dev/null
+		declare -p BUILDTOOLVER 2>/dev/null
 		printf '_chrootbuild "$@" || exit\n'
 
 		if (( run_namcap )); then
@@ -213,7 +215,10 @@ _chrootbuild() {
 	# use "$" in arguments to commands with "sudo -i".  ${foo} or
 	# ${1} is OK, but $foo or $1 isn't.
 	# https://bugzilla.sudo.ws/show_bug.cgi?id=765
-	sudo --preserve-env=SOURCE_DATE_EPOCH -iu builduser bash -c 'cd /startdir; makepkg "$@"' -bash "$@"
+	sudo --preserve-env=SOURCE_DATE_EPOCH \
+		--preserve-env=BUILDTOOL \
+		--preserve-env=BUILDTOOLVER \
+		-iu builduser bash -c 'cd /startdir; makepkg "$@"' -bash "$@"
 	ret=$?
 	case $ret in
 		0|14)
@@ -298,7 +303,7 @@ done
 [[ -n $makepkg_user && -z $(id -u "$makepkg_user") ]] && die 'Invalid makepkg user.'
 makepkg_user=${makepkg_user:-${SUDO_USER:-$USER}}
 
-check_root SOURCE_DATE_EPOCH,GNUPGHOME,SRCDEST,SRCPKGDEST,PKGDEST,LOGDEST,MAKEFLAGS,PACKAGER
+check_root SOURCE_DATE_EPOCH,BUILDTOOL,BUILDTOOLVER,GNUPGHOME,SRCDEST,SRCPKGDEST,PKGDEST,LOGDEST,MAKEFLAGS,PACKAGER
 
 # Canonicalize chrootdir, getting rid of trailing /
 chrootdir=$(readlink -e "$passeddir")

--- a/makerepropkg.in
+++ b/makerepropkg.in
@@ -178,6 +178,8 @@ parse_buildinfo < <(bsdtar -xOqf "${splitpkgs[0]}" .BUILDINFO)
 export SOURCE_DATE_EPOCH="${buildinfo[builddate]}"
 PACKAGER="${buildinfo[packager]}"
 BUILDDIR="${buildinfo[builddir]}"
+BUILDTOOL="${buildinfo[buildtool]}"
+BUILDTOOLVER="${buildinfo[buildtoolver]}"
 PKGEXT=${splitpkgs[0]#${splitpkgs[0]%.pkg.tar*}}
 
 # nuke and restore reproducible testenv
@@ -201,7 +203,7 @@ makechrootpkg -r "${buildroot}" -l "${chroot}" -- --packagelist || exit 1
 
 # set detected makepkg.conf options
 {
-    for var in PACKAGER BUILDDIR PKGEXT; do
+    for var in PACKAGER BUILDDIR BUILDTOOL BUILDTOOLVER PKGEXT; do
         printf '%s=%s\n' "${var}" "${!var@Q}"
     done
     printf 'OPTIONS=(%s)\n' "${buildopts[*]@Q}"


### PR DESCRIPTION
This helps to map the correct build tool configs that are required to
reproduce a specific package and have the appropriate *FLAGS etc.