### PR TITLE
Sync makepkg.conf with pacman 6.0.1-2

### DIFF
--- a/makepkg-x86_64.conf
+++ b/makepkg-x86_64.conf
@@ -11,10 +11,10 @@
 #
 #-- The download utilities that makepkg should use to acquire sources
 #  Format: 'protocol::agent'
-DLAGENTS=('file::/usr/bin/curl -gqC - -o %o %u'
-          'ftp::/usr/bin/curl -gqfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
-          'http::/usr/bin/curl -gqb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
-          'https::/usr/bin/curl -gqb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+DLAGENTS=('file::/usr/bin/curl -qgC - -o %o %u'
+          'ftp::/usr/bin/curl -qgfC - --ftp-pasv --retry 3 --retry-delay 3 -o %o %u'
+          'http::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
+          'https::/usr/bin/curl -qgb "" -fLC - --retry 3 --retry-delay 3 -o %o %u'
           'rsync::/usr/bin/rsync --no-motd -z %u %o'
           'scp::/usr/bin/scp -C %u %o')
 


### PR DESCRIPTION
Includes the following hotfix:

> upgpkg: pacman 6.0.1-2: makepkg.conf: Pass -q as the first option to curl
>
> This is needed to disable reading the curlrc config file (if it exists).
>
> Same change submitted to upstream pacman:
> https://lists.archlinux.org/pipermail/pacman-dev/2021-September/025348.html