### PR TITLE
Updated comments for makepkg defaults

### DIFF
--- a/makepkg-x86_64.conf
+++ b/makepkg-x86_64.conf
@@ -57,7 +57,7 @@ DEBUG_CXXFLAGS="-g -fvar-tracking-assignments"
 # BUILD ENVIRONMENT
 #########################################################################
 #
-# Makepkg defaults: BUILDENV=(!distcc !color !ccache check !sign)
+# Makepkg defaults: BUILDENV=(!distcc color !ccache check !sign)
 #  A negated environment option will do the opposite of the comments below.
 #
 #-- distcc:   Use the Distributed C/C++/ObjC compiler
@@ -80,7 +80,7 @@ BUILDENV=(!distcc color !ccache check !sign)
 #   These are default values for the options=() settings
 #########################################################################
 #
-# Makepkg defaults: OPTIONS=(!strip docs libtool staticlibs emptydirs !zipman !purge !debug !lto)
+# Makepkg defaults: OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug lto)
 #  A negated option will do the opposite of the comments below.
 #
 #-- strip:      Strip symbols from binaries/libraries


### PR DESCRIPTION
This updates the comments for `makepkg.conf` defaults, such that they match with the default values.