### PR TITLE
Use --noconfirm instead of piping yes

### DIFF
--- a/makechrootpkg.in
+++ b/makechrootpkg.in
@@ -137,7 +137,7 @@ install_packages() {
 
 	cp -- "${install_pkgs[@]}" "$copydir/root/"
 	arch-nspawn "$copydir" "${bindmounts_ro[@]}" "${bindmounts_rw[@]}" \
-		bash -c 'yes y | pacman -U -- "$@"' -bash "${pkgnames[@]/#//root/}"
+		bash -c 'pacman -U --noconfirm -- "$@"' -bash "${pkgnames[@]/#//root/}"
 	ret=$?
 	rm -- "${pkgnames[@]/#/$copydir/root/}"
 


### PR DESCRIPTION
Prevents this:

<details><summary><code>Enter a number (default=1): error: invalid number: y</code></summary><pre>

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): rror: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y

Enter a number (default=1): error: invalid number: y</pre></details>

If any non-default action is required before installing packages, IMHO the user should be required to do them before running `makechrootpkg`.