### PR TITLE
sogrep: fail if links database cannot be retrieved

### DIFF
--- a/sogrep.in
+++ b/sogrep.in
@@ -36,8 +36,11 @@ recache() {
             local dbpath=${SOCACHE_DIR}/${arch}/${repo}.links.tar.gz
             mkdir -p "${dbpath%/*}"
             (( VERBOSE )) && echo "Fetching ${repo}.links.tar.gz..."
-            curl -LR "${verbosity}" -o "${dbpath}" -z "${dbpath}" \
-                "${SOLINKS_MIRROR}/${repo}/os/${arch}/${repo}.links.tar.gz"
+            if ! curl -fLR "${verbosity}" -o "${dbpath}" -z "${dbpath}" \
+                "${SOLINKS_MIRROR}/${repo}/os/${arch}/${repo}.links.tar.gz"; then
+                echo "error: failed to download links database for repo ${repo}"
+                exit 1
+            fi
         done
     done
 }


### PR DESCRIPTION
If the links database (for some reason) does not exist on the mirror, curl will save the html 404 page as `${repo}.links.tar.gz` in the cache, and `sogrep` will later fail with a decompression error from `bsdtar`.

This patch adds `-f` to curl so it doesn't save the error page, and exit after displaying an error in such case.